### PR TITLE
options.skip

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ Default value: `.css-wrap`
 
 Provide a namespace selector in which to wrap CSS.
 
+#### options.skip
+Type: `Regular expression`
+Default value: `null`
+
+Skip css rules by regular expressions
+
 ## Changelog
 
 v0.0.1 - Initial Release
+v0.0.2 - Added options.skip

--- a/css_wrap.js
+++ b/css_wrap.js
@@ -3,7 +3,7 @@
  * https://github.com/benignware/css-wrap
  *
  * @See https://github.com/benignware/grunt-css-wrap
- * 
+ *
  * Forked and enhanced
  * https://github.com/zanzamar/grunt-css-wrap
  *
@@ -23,6 +23,7 @@ var
     return list.map( function( r ) {
       if ( r.selectors ) {
         r.selectors.forEach( function( s, index ) {
+          if (options.skip && options.skip.test(s)) return
           var selector = options.selector ? options.selector + " " + s : s;
           r.selectors[ index ] = selector;
         });
@@ -36,7 +37,8 @@ var
   css_wrap = function( string, options ) {
     options = deepmerge({
       // Defaults
-      selector: ".css-wrap"
+      selector: ".css-wrap",
+      skip: null
     }, options || {});
     if (fs.existsSync(path.resolve(string))) {
       string = fs.readFileSync(string).toString();

--- a/test/css_wrap_test.js
+++ b/test/css_wrap_test.js
@@ -30,22 +30,23 @@ exports.css_wrap = {
   },
   test: function(test) {
     test.expect(1);
-    
+
     var
       options = {
-        selector: '.my-app'
+        selector: '.my-app',
+        skip: /^\.skip-me/
       },
       result = css_wrap(path.join(__dirname, '/fixtures/styles.css'), options),
       actual,
       expected;
-    
+
     mkdirp('tmp');
     fs.writeFileSync('tmp/styles.css', result);
-    
+
     actual = fs.readFileSync('tmp/styles.css').toString();
     expected = fs.readFileSync(path.join(__dirname, '/expected/styles.css')).toString();
-    
-    test.equal(actual, expected, 'CSS Files should match');
+
+    test.strictEqual(actual, expected, 'CSS Files should match');
 
     test.done();
   }

--- a/test/expected/styles.css
+++ b/test/expected/styles.css
@@ -3,7 +3,7 @@
 }
 
 .skip-me {
-  bacground: red;
+  background: red;
 }
 
 @media (min-width: 768px) {

--- a/test/expected/styles.css
+++ b/test/expected/styles.css
@@ -2,6 +2,10 @@
   background: green;
 }
 
+.skip-me {
+  bacground: red;
+}
+
 @media (min-width: 768px) {
   .my-app .some-css-selector {
     width: 750px;

--- a/test/fixtures/styles.css
+++ b/test/fixtures/styles.css
@@ -1,6 +1,11 @@
 .some-css-selector {
   background: green;
 }
+
+.skip-me {
+  bacground: red;
+}
+
 @media (min-width: 768px) {
   .some-css-selector {
     width: 750px;

--- a/test/fixtures/styles.css
+++ b/test/fixtures/styles.css
@@ -3,7 +3,7 @@
 }
 
 .skip-me {
-  bacground: red;
+  background: red;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
This is very useful if your css contains styles for the class, that you want to wrap everything into e.g.

`.sky-component {styless..}` + `selector: '.sky-component'` will produce `.sky-component .sky-component` rule, which most of people wouldn't want
