### PR TITLE
fixed: open empty file error.

### DIFF
--- a/css_wrap.js
+++ b/css_wrap.js
@@ -41,7 +41,12 @@ var
       skip: null
     }, options || {});
     if (fs.existsSync(path.resolve(string))) {
-      string = fs.readFileSync(string).toString();
+      try {
+        string = fs.readFileSync(string).toString()
+      } catch (error) {
+        console.log('empty file skipped!');
+        return '';
+      }
     }
     var css = css_parse( string );
     css.stylesheet.rules = processRules( css.stylesheet.rules, options );


### PR DESCRIPTION
thx this plugin,  fixed fs.readFileSync open empty file error.

![image](https://user-images.githubusercontent.com/11495164/55312143-4ff8a180-5497-11e9-9dcc-3626691de045.png)

